### PR TITLE
Change order for value matchers

### DIFF
--- a/src/Storage/Query/QueryParameterParser.php
+++ b/src/Storage/Query/QueryParameterParser.php
@@ -43,6 +43,7 @@ class QueryParameterParser
         $word = "[\p{L}\p{N}_]+";
 
         // @codingStandardsIgnoreStart
+        $this->addValueMatcher("($word)",                   ['value' => '$1', 'operator' => 'eq']);
         $this->addValueMatcher("<($word)",                  ['value' => '$1', 'operator' => 'lt']);
         $this->addValueMatcher("<=($word)",                 ['value' => '$1', 'operator' => 'lte']);
         $this->addValueMatcher(">=($word)",                 ['value' => '$1', 'operator' => 'gte']);
@@ -52,7 +53,6 @@ class QueryParameterParser
         $this->addValueMatcher('!\[([\p{L}\p{N} ,]+)\]',    ['value' => function ($val) { return explode(',', $val); }, 'operator' => 'notIn']);
         $this->addValueMatcher('\[([\p{L}\p{N} ,]+)\]',     ['value' => function ($val) { return explode(',', $val); }, 'operator' => 'in']);
         $this->addValueMatcher("(%$word|$word%|%$word%)",   ['value' => '$1', 'operator' => 'like']);
-        $this->addValueMatcher("($word)",                   ['value' => '$1', 'operator' => 'eq']);
         // @codingStandardsIgnoreEnd
 
         $this->addFilterHandler([$this, 'defaultFilterHandler']);


### PR DESCRIPTION
Unfortunately some text values are interpreted as **_"<($word)"_** which can cause the record is found in database although this value doesn't exist in database.

I can't make all proper test but I think _eq_ operator should be first.
